### PR TITLE
move ucan from token string to use idiomatic TryFrom and FromStr conversion(s)

### DIFF
--- a/ucan-key-support/src/ed25519.rs
+++ b/ucan-key-support/src/ed25519.rs
@@ -87,7 +87,7 @@ mod tests {
 
         let mut did_parser = DidParser::new(&[(ED25519_MAGIC_BYTES, bytes_to_ed25519_key)]);
 
-        let ucan = Ucan::try_from_token_string(token_string.as_str()).unwrap();
+        let ucan = Ucan::try_from(token_string).unwrap();
         ucan.check_signature(&mut did_parser).await.unwrap();
     }
 }

--- a/ucan-key-support/src/rsa.rs
+++ b/ucan-key-support/src/rsa.rs
@@ -120,7 +120,7 @@ mod tests {
 
         let mut did_parser = DidParser::new(&[(RSA_MAGIC_BYTES, bytes_to_rsa_key)]);
 
-        let ucan = Ucan::try_from_token_string(token_string.as_str()).unwrap();
+        let ucan = Ucan::try_from(token_string).unwrap();
         ucan.check_signature(&mut did_parser).await.unwrap();
     }
 }

--- a/ucan-key-support/src/web_crypto.rs
+++ b/ucan-key-support/src/web_crypto.rs
@@ -259,7 +259,7 @@ mod tests {
             .unwrap();
 
         let mut did_parser = DidParser::new(&[(RSA_MAGIC_BYTES, bytes_to_rsa_key)]);
-        let ucan = Ucan::try_from_token_string(token.as_str()).unwrap();
+        let ucan = Ucan::try_from(token.as_str()).unwrap();
 
         ucan.check_signature(&mut did_parser).await.unwrap();
     }

--- a/ucan/src/chain.rs
+++ b/ucan/src/chain.rs
@@ -116,7 +116,7 @@ impl ProofChain {
     where
         S: UcanJwtStore,
     {
-        let ucan = Ucan::try_from_token_string(ucan_token_string)?;
+        let ucan = Ucan::try_from(ucan_token_string)?;
         Self::from_ucan(ucan, did_parser, store).await
     }
 

--- a/ucan/src/ipld/ucan.rs
+++ b/ucan/src/ipld/ucan.rs
@@ -47,10 +47,10 @@ impl TryFrom<&Ucan> for UcanIpld {
             ))?,
             att: ucan.attenuation().clone(),
             prf,
-            exp: ucan.expires_at().clone(),
+            exp: *ucan.expires_at(),
             fct: ucan.facts().clone(),
             nnc: ucan.nonce().as_ref().cloned(),
-            nbf: ucan.not_before().clone(),
+            nbf: *ucan.not_before(),
         })
     }
 }
@@ -168,7 +168,7 @@ mod tests {
             .encode()
             .unwrap();
 
-        let ucan = Ucan::try_from_token_string(&jwt).unwrap();
+        let ucan = Ucan::try_from(jwt.as_str()).unwrap();
         let ucan_ipld = UcanIpld::try_from(&ucan).unwrap();
 
         let decoded_ucan_ipld = dag_cbor_roundtrip(&ucan_ipld).unwrap();

--- a/ucan/src/tests/ucan.rs
+++ b/ucan/src/tests/ucan.rs
@@ -30,7 +30,7 @@ mod validate {
             .unwrap();
 
         let encoded_ucan = ucan.encode().unwrap();
-        let decoded_ucan = Ucan::try_from_token_string(encoded_ucan.as_str()).unwrap();
+        let decoded_ucan = Ucan::try_from(encoded_ucan.as_str()).unwrap();
 
         decoded_ucan.validate(&mut did_parser).await.unwrap();
     }


### PR DESCRIPTION
Howdy @cdata.

It seemed to me that `try_from_token_string`, as I've seen in some public uses, should, instead, just follow from the implementation of the common Rust [TryFrom](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) trait, as with other things. I also did some clean-up here to remove the nested matches. 

