### PR TITLE
proofchain w/ builder pattern + minor convert updates

### DIFF
--- a/ucan/Cargo.toml
+++ b/ucan/Cargo.toml
@@ -21,7 +21,6 @@ default = []
 
 [dependencies]
 anyhow = "1.0"
-async-recursion = "1.0"
 async-std = "1.0"
 async-trait = "0.1"
 base64 = "0.13"
@@ -42,10 +41,10 @@ url = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: This is needed so that rand can be included in WASM builds
-getrandom = { version = "~0.2", features = ["js"] }
+getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "^1", features = ["macros", "test-util"] }
+tokio = { version = "1.0", features = ["macros", "test-util"] }
 
 [dev-dependencies]
 did-key = "0.2"

--- a/ucan/src/chain.rs
+++ b/ucan/src/chain.rs
@@ -7,10 +7,27 @@ use crate::{
     store::UcanJwtStore,
     ucan::Ucan,
 };
-use anyhow::{anyhow, Result};
-use async_recursion::async_recursion;
+use anyhow::{anyhow, Context, Result};
 use cid::Cid;
-use std::{collections::BTreeSet, fmt::Debug};
+#[cfg(not(target_arch = "wasm32"))]
+use futures::future::{BoxFuture, FutureExt};
+#[cfg(target_arch = "wasm32")]
+use futures::future::{FutureExt, LocalBoxFuture};
+use std::{
+    collections::BTreeSet,
+    convert::TryFrom,
+    fmt::{self, Debug},
+    str::FromStr,
+    sync::Arc,
+};
+
+/// Type alias for handling recursive async fns, akin to async_recursion crate.
+#[cfg(not(target_arch = "wasm32"))]
+type BuildResult<'a, S> = BoxFuture<'a, Result<ProofChain<'a, S>>>;
+
+/// Type alias for handling recursive async fns in wasm, akin to async_recursion crate.
+#[cfg(target_arch = "wasm32")]
+type BuildResult<'a, S> = LocalBoxFuture<'a, Result<ProofChain<'a, S>>>;
 
 const PROOF_DELEGATION_SEMANTICS: ProofDelegationSemantics = ProofDelegationSemantics {};
 
@@ -38,130 +55,170 @@ where
 }
 
 /// A deserialized chain of ancestral proofs that are linked to a UCAN
-#[derive(Debug)]
-pub struct ProofChain {
+pub struct ProofChain<'a, S>
+where
+    S: UcanJwtStore,
+{
     ucan: Ucan,
-    proofs: Vec<ProofChain>,
+    proofs: Vec<ProofChain<'a, S>>,
     redelegations: BTreeSet<usize>,
+    did_parser: Option<Arc<DidParser>>,
+    store: Option<&'a S>,
 }
 
-impl ProofChain {
-    /// Instantiate a [ProofChain] from a [Ucan], given a [UcanJwtStore] and [DidParser]
-    #[cfg_attr(target_arch = "wasm32", async_recursion(?Send))]
-    #[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
-    pub async fn from_ucan<S>(
-        ucan: Ucan,
-        did_parser: &mut DidParser,
-        store: &S,
-    ) -> Result<ProofChain>
-    where
-        S: UcanJwtStore,
-    {
-        ucan.validate(did_parser).await?;
+impl<S> Debug for ProofChain<'_, S>
+where
+    S: UcanJwtStore,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProofChain")
+            .field("ucan", &self.ucan)
+            .field("proofs", &self.proofs)
+            .field("redelegations", &self.redelegations)
+            .finish()
+    }
+}
 
-        let mut proofs: Vec<ProofChain> = Vec::new();
-
-        for cid_string in ucan.proofs().iter() {
-            let cid = Cid::try_from(cid_string.as_str())?;
-            let ucan_token = store.require_token(&cid).await?;
-            let proof_chain = Self::try_from_token_string(&ucan_token, did_parser, store).await?;
-            proof_chain.validate_link_to(&ucan)?;
-            proofs.push(proof_chain);
-        }
-
-        let mut redelegations = BTreeSet::<usize>::new();
-
-        for capability in CapabilityIterator::new(&ucan, &PROOF_DELEGATION_SEMANTICS) {
-            match capability.with() {
-                With::Resource {
-                    kind: Resource::Scoped(ProofSelection::All),
-                } => {
-                    for index in 0..proofs.len() {
-                        redelegations.insert(index);
-                    }
-                }
-                With::Resource {
-                    kind: Resource::Scoped(ProofSelection::Index(index)),
-                } => {
-                    if *index < proofs.len() {
-                        redelegations.insert(*index);
-                    } else {
-                        return Err(anyhow!(
-                            "Unable to redelegate proof; no proof at zero-based index {}",
-                            index
-                        ));
-                    }
-                }
-                _ => continue,
-            }
-        }
-
-        Ok(ProofChain {
+impl<'a, S> ProofChain<'a, S>
+where
+    S: UcanJwtStore,
+{
+    /// Instantiate a bare [ProofChain] from a [Ucan].
+    pub fn from_ucan(ucan: Ucan) -> Self {
+        Self {
             ucan,
-            proofs,
-            redelegations,
+            proofs: vec![],
+            redelegations: BTreeSet::<usize>::new(),
+            did_parser: None,
+            store: None,
+        }
+    }
+
+    /// Validate and set [DidParser] for [ProofChain] build.
+    pub async fn with_parser(mut self, mut did_parser: DidParser) -> Result<ProofChain<'a, S>> {
+        self.ucan.validate(&mut did_parser).await?;
+        self.did_parser = Some(Arc::new(did_parser));
+        Ok(self)
+    }
+
+    async fn with_parser_arc(
+        mut self,
+        mut did_parser: Arc<DidParser>,
+    ) -> Result<ProofChain<'a, S>> {
+        self.ucan.validate(Arc::make_mut(&mut did_parser)).await?;
+        self.did_parser = Some(did_parser);
+        Ok(self)
+    }
+
+    /// Set [UcanJwtStore] for [ProofChain] build.
+    pub fn with_store(mut self, store: &'a S) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    /// Instantiate a bare [ProofChain] from a [Cid], given a [UcanJwtStore].
+    /// The [Cid] must resolve to a JWT token string and be available in the store.
+    pub async fn from_cid(cid: &Cid, store: &'a S) -> Result<ProofChain<'a, S>> {
+        let ucan_token = store.require_token(cid).await?;
+        Ok(Self {
+            ucan: Ucan::try_from(ucan_token)?,
+            proofs: vec![],
+            redelegations: BTreeSet::<usize>::new(),
+            did_parser: None,
+            store: Some(store),
         })
     }
 
-    /// Instantiate a [ProofChain] from a [Cid], given a [UcanJwtStore] and [DidParser]
-    /// The [Cid] must resolve to a JWT token string
-    pub async fn from_cid<S>(cid: &Cid, did_parser: &mut DidParser, store: &S) -> Result<ProofChain>
-    where
-        S: UcanJwtStore,
-    {
-        Self::try_from_token_string(&store.require_token(cid).await?, did_parser, store).await
-    }
-
-    /// Instantiate a [ProofChain] from a JWT token string, given a [UcanJwtStore] and [DidParser]
-    pub async fn try_from_token_string<'a, S>(
-        ucan_token_string: &str,
-        did_parser: &mut DidParser,
-        store: &S,
-    ) -> Result<ProofChain>
-    where
-        S: UcanJwtStore,
-    {
-        let ucan = Ucan::try_from(ucan_token_string)?;
-        Self::from_ucan(ucan, did_parser, store).await
-    }
-
-    fn validate_link_to(&self, ucan: &Ucan) -> Result<()> {
-        let audience = self.ucan.audience();
-        let issuer = ucan.issuer();
-
-        match audience == issuer {
-            true => match self.ucan.lifetime_encompasses(ucan) {
-                true => Ok(()),
-                false => Err(anyhow!("Invalid UCAN link: lifetime exceeds attenuation")),
-            },
-            false => Err(anyhow!(
-                "Invalid UCAN link: audience {} does not match issuer {}",
-                audience,
-                issuer
-            )),
-        }
-    }
-
+    /// Get the [ProofChain]'s ucan.
     pub fn ucan(&self) -> &Ucan {
         &self.ucan
     }
 
-    pub fn proofs(&self) -> &Vec<ProofChain> {
+    /// Get the [ProofChain]'s proofs.
+    pub fn proofs(&self) -> &Vec<Self> {
         &self.proofs
     }
 
-    pub fn reduce_capabilities<Semantics, S, A>(
+    /// Build-out entire [ProofChain] after setting a [UcanJwtStore] and [DidParser].
+    pub fn build(mut self) -> BuildResult<'a, S> {
+        let proof_chain = async move {
+            let did_parser = self
+                .did_parser
+                .take()
+                .context("No parser set for ProofChain")?;
+
+            for cid_string in self.ucan.proofs().iter() {
+                let cid = Cid::try_from(cid_string.as_str())?;
+
+                let proof_chain =
+                    ProofChain::from_cid(&cid, self.store.context("No store set for ProofChain")?)
+                        .await?
+                        .with_parser_arc(Arc::clone(&did_parser))
+                        .await?
+                        .build()
+                        .await?;
+
+                proof_chain.validate_link_to(&self.ucan)?;
+                self.proofs.push(proof_chain);
+
+                for capability in CapabilityIterator::new(&self.ucan, &PROOF_DELEGATION_SEMANTICS) {
+                    match capability.with() {
+                        With::Resource {
+                            kind: Resource::Scoped(ProofSelection::All),
+                        } => {
+                            for index in 0..self.proofs.len() {
+                                self.redelegations.insert(index);
+                            }
+                        }
+                        With::Resource {
+                            kind: Resource::Scoped(ProofSelection::Index(index)),
+                        } => {
+                            if *index < self.proofs.len() {
+                                self.redelegations.insert(*index);
+                            } else {
+                                return Err(anyhow!(
+                                    "Unable to redelegate proof; no proof at zero-based index {}",
+                                    index
+                                ));
+                            }
+                        }
+                        _ => continue,
+                    }
+                }
+            }
+
+            Ok(ProofChain {
+                ucan: self.ucan,
+                proofs: self.proofs,
+                redelegations: self.redelegations,
+                did_parser: Some(did_parser),
+                store: self.store,
+            })
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            proof_chain.boxed()
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            proof_chain.boxed_local()
+        }
+    }
+
+    pub fn reduce_capabilities<Semantics, Sc, A>(
         &self,
         semantics: &Semantics,
-    ) -> Vec<CapabilityInfo<S, A>>
+    ) -> Vec<CapabilityInfo<Sc, A>>
     where
-        Semantics: CapabilitySemantics<S, A>,
-        S: Scope,
+        Semantics: CapabilitySemantics<Sc, A>,
+        Sc: Scope,
         A: Action,
     {
         // Get the set of inherited attenuations (excluding redelegations)
         // before further attenuating by own lifetime and capabilities:
-        let ancestral_capability_infos: Vec<CapabilityInfo<S, A>> = self
+        let ancestral_capability_infos: Vec<CapabilityInfo<Sc, A>> = self
             .proofs
             .iter()
             .enumerate()
@@ -176,7 +233,7 @@ impl ProofChain {
 
         // Get the set of capabilities that are blanket redelegated from
         // ancestor proofs (via the prf: resource):
-        let mut redelegated_capability_infos: Vec<CapabilityInfo<S, A>> = self
+        let mut redelegated_capability_infos: Vec<CapabilityInfo<Sc, A>> = self
             .redelegations
             .iter()
             .flat_map(|index| {
@@ -199,16 +256,17 @@ impl ProofChain {
 
         // Get the claimed attenuations of this ucan, cross-checking ancestral
         // attenuations to discover the originating authority
-        let mut self_capability_infos: Vec<CapabilityInfo<S, A>> = match self.proofs.len() {
-            0 => self_capabilities_iter
+        let mut self_capability_infos: Vec<CapabilityInfo<Sc, A>> = if self.proofs.is_empty() {
+            self_capabilities_iter
                 .map(|capability| CapabilityInfo {
                     originators: BTreeSet::from_iter(vec![self.ucan.issuer().to_string()]),
                     capability,
                     not_before: *self.ucan.not_before(),
                     expires_at: *self.ucan.expires_at(),
                 })
-                .collect(),
-            _ => self_capabilities_iter
+                .collect()
+        } else {
+            self_capabilities_iter
                 .map(|capability| {
                     let mut originators = BTreeSet::<String>::new();
 
@@ -235,12 +293,12 @@ impl ProofChain {
                         expires_at: *self.ucan.expires_at(),
                     }
                 })
-                .collect(),
+                .collect()
         };
 
         self_capability_infos.append(&mut redelegated_capability_infos);
 
-        let mut merged_capability_infos = Vec::<CapabilityInfo<S, A>>::new();
+        let mut merged_capability_infos = Vec::<CapabilityInfo<Sc, A>>::new();
 
         // Merge redundant capabilities (accounting for redelegation), ensuring
         // that discrete originators are aggregated as we go
@@ -261,5 +319,57 @@ impl ProofChain {
         }
 
         merged_capability_infos
+    }
+
+    fn validate_link_to(&self, ucan: &Ucan) -> Result<()> {
+        let audience = self.ucan.audience();
+        let issuer = ucan.issuer();
+
+        match audience == issuer {
+            true if self.ucan.lifetime_encompasses(ucan) => Ok(()),
+            true => Err(anyhow!("Invalid UCAN link: lifetime exceeds attenuation")),
+            false => Err(anyhow!(
+                "Invalid UCAN link: audience {} does not match issuer {}",
+                audience,
+                issuer
+            )),
+        }
+    }
+}
+
+/// Instantiate a [ProofChain] from a JWT token string reference.
+impl<'a, S> TryFrom<&'a str> for ProofChain<'a, S>
+where
+    S: UcanJwtStore,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(ucan_token: &str) -> Result<Self, Self::Error> {
+        ProofChain::from_str(ucan_token)
+    }
+}
+
+/// Instantiate a [ProofChain] from a JWT token owned string.
+impl<S> TryFrom<String> for ProofChain<'_, S>
+where
+    S: UcanJwtStore,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(ucan_token: String) -> Result<Self, Self::Error> {
+        ProofChain::from_str(ucan_token.as_str())
+    }
+}
+
+/// Instantiate a [ProofChain] from a JWT token owned string reference.
+impl<S> FromStr for ProofChain<'_, S>
+where
+    S: UcanJwtStore,
+{
+    type Err = anyhow::Error;
+
+    fn from_str(ucan_token: &str) -> Result<Self, Self::Err> {
+        let ucan = Ucan::try_from(ucan_token)?;
+        Ok(Self::from_ucan(ucan))
     }
 }

--- a/ucan/src/crypto/did.rs
+++ b/ucan/src/crypto/did.rs
@@ -19,9 +19,10 @@ pub const P256_MAGIC_BYTES: &[u8] = &[0x80, 0x24];
 pub const SECP256K1_MAGIC_BYTES: &[u8] = &[0xe7, 0x1];
 
 /// A parser that is able to convert from a DID string into a corresponding
-/// [`crypto::SigningKey`] implementation. The parser extracts the signature
+/// [`KeyMaterial`] implementation. The parser extracts the signature
 /// magic bytes from a given DID and tries to match them to a corresponding
 /// constructor function that produces a `SigningKey`.
+#[derive(Clone)]
 pub struct DidParser {
     key_constructors: KeyConstructors,
     key_cache: KeyCache,

--- a/ucan/src/ipld/signature.rs
+++ b/ucan/src/ipld/signature.rs
@@ -20,7 +20,7 @@ const EIP191_VARSIG_PREFIX: u64 = 0xd191;
 /// counterpart representation and vice-versa
 /// Note, not all valid JWT signature algorithms are represented by this
 /// library, nor are all valid varsig prefixes
-/// See https://github.com/ucan-wg/ucan-ipld#25-signature
+/// See <https://github.com/ucan-wg/ucan-ipld#25-signature>
 #[derive(Debug, Eq, PartialEq)]
 pub enum VarsigPrefix {
     NonStandard,
@@ -116,7 +116,7 @@ impl TryFrom<u64> for VarsigPrefix {
 
 /// An envelope for the UCAN-IPLD-equivalent of a UCAN's JWT signature, which
 /// is a specified prefix in front of the raw signature bytes
-/// See: https://github.com/ucan-wg/ucan-ipld#25-signature
+/// See: <https://github.com/ucan-wg/ucan-ipld#25-signature>
 #[repr(transparent)]
 #[derive(Serialize, Deserialize)]
 pub struct Signature(pub Vec<u8>);

--- a/ucan/src/ipld/ucan.rs
+++ b/ucan/src/ipld/ucan.rs
@@ -8,7 +8,7 @@ use crate::{
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{convert::TryFrom, str::FromStr};
+use std::{borrow::Borrow, convert::TryFrom, str::FromStr};
 
 #[derive(Serialize, Deserialize)]
 pub struct UcanIpld {
@@ -25,6 +25,14 @@ pub struct UcanIpld {
 
     pub nnc: Option<String>,
     pub nbf: Option<u64>,
+}
+
+impl TryFrom<Ucan> for UcanIpld {
+    type Error = anyhow::Error;
+
+    fn try_from(ucan: Ucan) -> Result<Self, Self::Error> {
+        ucan.borrow().try_into()
+    }
 }
 
 impl TryFrom<&Ucan> for UcanIpld {

--- a/ucan/src/lib.rs
+++ b/ucan/src/lib.rs
@@ -11,7 +11,7 @@
 //! This crate offers the [`builder::UcanBuilder`] abstraction to generate
 //! signed UCAN tokens.
 //!
-//! To generate a signed token, you need to provide a [`crypto::SigningKey`]
+//! To generate a signed token, you need to provide a [`crypto::KeyMaterial`]
 //! implementation. For more information on providing a signing key, see the
 //! [`crypto`] module documentation.
 //!
@@ -52,16 +52,21 @@
 //!     // You must bring your own key support
 //! ];
 //!
-//! async fn get_capabilities<'a, Semantics, S, A, Store>(ucan_token: &'a str, semantics: &'a Semantics, store: &'a Store) -> Result<Vec<CapabilityInfo<S, A>>, anyhow::Error>
+//! async fn get_capabilities<'a, Semantics, S, A, Store>(ucan_token: &'a str, semantics: &'a Semantics, store: Store) -> Result<Vec<CapabilityInfo<S, A>>, anyhow::Error>
 //!     where
 //!         Semantics: CapabilitySemantics<S, A>,
 //!         S: Scope,
 //!         A: Action,
-//!         Store: UcanJwtStore
+//!         Store: UcanJwtStore + Default
 //! {
 //!     let mut did_parser = DidParser::new(SUPPORTED_KEY_TYPES);
 //!
-//!     Ok(ProofChain::try_from_token_string(ucan_token, &mut did_parser, store).await?
+//!     Ok(ProofChain::try_from(ucan_token)?
+//!         .with_parser(did_parser)
+//!         .await?
+//!         .with_store(&store)
+//!         .build()
+//!         .await?
 //!         .reduce_capabilities(semantics))
 //! }
 //! ```

--- a/ucan/src/ucan.rs
+++ b/ucan/src/ucan.rs
@@ -194,7 +194,7 @@ impl TryFrom<Ucan> for Cid {
     }
 }
 
-/// Deserialize an encoded UCAN token string reference into a UCAN
+/// Deserialize an encoded UCAN token string reference into a UCAN.
 impl<'a> TryFrom<&'a str> for Ucan {
     type Error = anyhow::Error;
 
@@ -203,7 +203,7 @@ impl<'a> TryFrom<&'a str> for Ucan {
     }
 }
 
-/// Deserialize an encoded UCAN token string into a UCAN
+/// Deserialize an encoded UCAN token string into a UCAN.
 impl TryFrom<String> for Ucan {
     type Error = anyhow::Error;
 
@@ -212,7 +212,7 @@ impl TryFrom<String> for Ucan {
     }
 }
 
-/// Deserialize an encoded UCAN token string reference into a UCAN
+/// Deserialize an encoded UCAN token string reference into a UCAN.
 impl FromStr for Ucan {
     type Err = anyhow::Error;
 


### PR DESCRIPTION
Personally, I felt that proofchain building felt more like a series of steps rather than one fn, b/c it always applied the parser (eventually `TODO` resolver) and store. This does keep the parser and store attached to a chain, but as private fields, not publically accessible. It's a bit more verbose, but also validates the parser in a separate step, which I like. 

In Draft mode, associated w/ issue #39. 

Includes:

- also convert for https://github.com/ucan-wg/rs-ucan/compare/zl/refactor-proofchain-to-builder?expand=1#diff-ac4bd4337ca259c2c4f1c479dbce49b390526e62ddf332a9016b050f193d5e63R30. 