### PR TITLE
ucan-key-support: add P-256 key support (aka ESRSA, aka secp256r1)

### DIFF
--- a/ucan-key-support/Cargo.toml
+++ b/ucan-key-support/Cargo.toml
@@ -26,6 +26,7 @@ bs58 = "0.4"
 ed25519-zebra = "3.1"
 log = "0.4"
 rsa = "0.7"
+p256 = "0.11"
 sha2 = { version = "0.10", features = ["oid"] }
 ucan = { path = "../ucan", version = "0.1.0" }
 

--- a/ucan-key-support/src/lib.rs
+++ b/ucan-key-support/src/lib.rs
@@ -5,4 +5,5 @@ extern crate log;
 pub mod web_crypto;
 
 pub mod ed25519;
+pub mod p256;
 pub mod rsa;

--- a/ucan-key-support/src/p256.rs
+++ b/ucan-key-support/src/p256.rs
@@ -1,0 +1,85 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+
+use p256::ecdsa::{
+    signature::{Signer, Verifier},
+    Signature, SigningKey as P256PrivateKey, VerifyingKey as P256PublicKey,
+};
+
+use ucan::crypto::KeyMaterial;
+
+pub use ucan::crypto::{did::P256_MAGIC_BYTES, JwtSignatureAlgorithm};
+
+pub fn bytes_to_p256_key(bytes: Vec<u8>) -> Result<Box<dyn KeyMaterial>> {
+    let public_key = P256PublicKey::try_from(bytes.as_slice())?;
+    Ok(Box::new(P256KeyMaterial(public_key, None)))
+}
+
+/// Support for NIST P-256 keys, aka secp256r1, aka ES256
+#[derive(Clone)]
+pub struct P256KeyMaterial(pub P256PublicKey, pub Option<P256PrivateKey>);
+
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl KeyMaterial for P256KeyMaterial {
+    fn get_jwt_algorithm_name(&self) -> String {
+        JwtSignatureAlgorithm::ES256.to_string()
+    }
+
+    async fn get_did(&self) -> Result<String> {
+        let bytes = [P256_MAGIC_BYTES, &self.0.to_encoded_point(true).to_bytes()].concat();
+        Ok(format!("did:key:z{}", bs58::encode(bytes).into_string()))
+    }
+
+    async fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
+        match self.1 {
+            Some(ref private_key) => {
+                let signature = private_key.sign(payload);
+                Ok(signature.as_ref().to_vec())
+            }
+            None => Err(anyhow!("No private key; cannot sign data")),
+        }
+    }
+
+    async fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<()> {
+        let signature = Signature::try_from(signature)?;
+        self.0
+            .verify(payload, &signature)
+            .map_err(|error| anyhow!("Could not verify signature: {:?}", error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bytes_to_p256_key, P256KeyMaterial, P256_MAGIC_BYTES};
+    use p256::ecdsa::{SigningKey as P256PrivateKey, VerifyingKey as P256PublicKey};
+    use ucan::{
+        builder::UcanBuilder,
+        crypto::{did::DidParser, KeyMaterial},
+        ucan::Ucan,
+    };
+
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_sign_and_verify_a_ucan() {
+        let private_key = P256PrivateKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+        let public_key = P256PublicKey::from(&private_key);
+
+        let key_material = P256KeyMaterial(public_key, Some(private_key));
+        let token_string = UcanBuilder::default()
+            .issued_by(&key_material)
+            .for_audience(key_material.get_did().await.unwrap().as_str())
+            .with_lifetime(60)
+            .build()
+            .unwrap()
+            .sign()
+            .await
+            .unwrap()
+            .encode()
+            .unwrap();
+
+        let mut did_parser = DidParser::new(&[(P256_MAGIC_BYTES, bytes_to_p256_key)]);
+
+        let ucan = Ucan::try_from(token_string).unwrap();
+        ucan.check_signature(&mut did_parser).await.unwrap();
+    }
+}


### PR DESCRIPTION
While it is possible for calling code to add arbitrary key support by implementing the KeyMaterial trait, it is helpful to have some popular key types included in the `ucan-key-support` crate.

The inclusion of P-256 is motivated by the support for that curve in the 'ts-ucan' npm library. Adding P-256 to `ucan-key-support` will mean the same set of keys are supported by both libraries out of the box.

This commit adds support for this key type via the `p256` crate, maintained by RustCrypto. These are the same maintainers as the 'rsa' crate, and several recursive dependencies are shared.

The implementation is basically directly copied from the 'ed25519' module.

This commit uses the somewhat out-of-date v0.9 of 'p256', to be compatible with other dependencies in this crate. It looks like the 'did-web' crate would need to update it's 'signatures' dependency for 'p256 v0.11' (and greater) to work.

----

I have looked at the license file (Apache) and agree to the terms, indicated by "signed off" on the commit.

I don't have a WASM dev environment setup, and don't know much about supporting WASM, so I haven't tested that config. Hopefully it just works, as it was copied from ed25519.

This closes #45 