### PR TITLE
chore: deps update to minor versions and fix did-key upstream dep

### DIFF
--- a/ucan-key-support/Cargo.toml
+++ b/ucan-key-support/Cargo.toml
@@ -20,26 +20,26 @@ version = "0.7.0-alpha.1"
 default = []
 
 [dependencies]
-anyhow = "1.0.52"
-async-trait = "0.1.52"
+anyhow = "1.0"
+async-trait = "0.1"
 bs58 = "0.4"
-ed25519-zebra = "^3"
+ed25519-zebra = "3.1"
 log = "0.4"
 rsa = "0.6"
 sha2 = "0.10"
 ucan = { path = "../ucan", version = "0.7.0-alpha.1" }
 
 [build-dependencies]
-npm_rs = "0.2.1"
+npm_rs = "1.0"
 
 [dev-dependencies]
 # NOTE: This is needed so that rand can be included in WASM builds
-getrandom = { version = "~0.2", features = ["js"] }
-rand = "~0.8"
-wasm-bindgen-test = "~0.3"
+getrandom = { version = "0.2", features = ["js"] }
+rand = "0.8"
+wasm-bindgen-test = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "^1", features = ["macros", "rt"] }
+tokio = { version = "1.21", features = ["macros", "rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/ucan/Cargo.toml
+++ b/ucan/Cargo.toml
@@ -20,24 +20,25 @@ edition = "2021"
 default = []
 
 [dependencies]
-anyhow = "^1"
-async-recursion = "^1"
-async-std = "^1"
-async-trait = "~0.1"
-base64 = "~0.13"
-bs58 = "~0.4"
-cid = "~0.8"
+anyhow = "1.0"
+async-recursion = "1.0"
+async-std = "1.0"
+async-trait = "0.1"
+base64 = "0.13"
+bs58 = "0.4"
+cid = "0.8"
+futures = "0.3"
 instant = { version = "0.1", features = ["wasm-bindgen", "stdweb"] }
-libipld-core = { version = "~0.14", features = ["serde-codec", "serde"] }
-libipld-json = "~0.14"
-log = "~0.4"
-rand = "~0.8"
-serde = { version = "^1", features = ["derive"] }
-serde_json = "^1"
-strum = "~0.24"
-strum_macros = "~0.24"
-unsigned-varint = "~0.7"
-url = "^2"
+libipld-core = { version = "0.14", features = ["serde-codec", "serde"] }
+libipld-json = "0.14"
+log = "0.4"
+rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+strum = "0.24"
+strum_macros = "0.24"
+unsigned-varint = "0.7"
+url = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: This is needed so that rand can be included in WASM builds
@@ -47,6 +48,6 @@ getrandom = { version = "~0.2", features = ["js"] }
 tokio = { version = "^1", features = ["macros", "test-util"] }
 
 [dev-dependencies]
-did-key = "0.1"
-serde_ipld_dagcbor = "~0.2"
-wasm-bindgen-test = "~0.3"
+did-key = "0.2"
+serde_ipld_dagcbor = "0.2"
+wasm-bindgen-test = "0.3"

--- a/ucan/src/tests/crypto.rs
+++ b/ucan/src/tests/crypto.rs
@@ -1,5 +1,5 @@
 mod did_from_keypair {
-    use did_key::{Bls12381KeyPairs, Ed25519KeyPair, Generate, KeyPair};
+    use did_key::{from_existing_key, Ed25519KeyPair, KeyMaterial as _KeyMaterial};
 
     use crate::crypto::KeyMaterial;
 
@@ -13,23 +13,10 @@ mod did_from_keypair {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_handles_ed25519_keys() {
         let pub_key = base64::decode("Hv+AVRD2WUjUFOsSNbsmrp9fokuwrUnjBcr92f0kxw4=").unwrap();
-        let keypair = KeyPair::Ed25519(Ed25519KeyPair::from_public_key(&pub_key));
+        let key = Ed25519KeyPair::from_public_key(&pub_key);
+        let keypair = from_existing_key::<Ed25519KeyPair>(&key.public_key_bytes(), None);
 
         let expected_did = "did:key:z6MkgYGF3thn8k1Fv4p4dWXKtsXCnLH7q9yw4QgNPULDmDKB";
-        let result_did = keypair.get_did().await.unwrap();
-
-        assert_eq!(expected_did, result_did.as_str());
-    }
-
-    #[allow(dead_code)]
-    // #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[ignore = "Public key is allegedly invalid size"]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_handles_bls12381_keys() {
-        let pub_key = base64::decode("Hv+AVRD2WUjUFOsSNbsmrp9fokuwrUnjBcr92f0kxw4=").unwrap();
-        let keypair = KeyPair::Bls12381G1G2(Bls12381KeyPairs::from_public_key(&pub_key));
-
-        let expected_did = "did:key:z6HpYD1br5P4QVh5rjRGAkBfKMWes44uhKmKdJ6dN2Nm9gHK";
         let result_did = keypair.get_did().await.unwrap();
 
         assert_eq!(expected_did, result_did.as_str());

--- a/ucan/src/tests/fixtures/crypto.rs
+++ b/ucan/src/tests/fixtures/crypto.rs
@@ -4,7 +4,7 @@ use crate::crypto::{
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use did_key::{CoreSign, Ed25519KeyPair, Fingerprint, KeyPair};
+use did_key::{from_existing_key, CoreSign, Ed25519KeyPair, Fingerprint, PatchedKeyPair};
 
 pub const SUPPORTED_KEYS: &KeyConstructorSlice = &[
     // https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L94
@@ -12,14 +12,15 @@ pub const SUPPORTED_KEYS: &KeyConstructorSlice = &[
 ];
 
 pub fn bytes_to_ed25519_key(bytes: Vec<u8>) -> Result<Box<dyn KeyMaterial>> {
-    Ok(Box::new(KeyPair::Ed25519(Ed25519KeyPair::from_public_key(
+    Ok(Box::new(from_existing_key::<Ed25519KeyPair>(
         bytes.as_slice(),
-    ))))
+        None,
+    )))
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl KeyMaterial for KeyPair {
+impl KeyMaterial for PatchedKeyPair {
     fn get_jwt_algorithm_name(&self) -> String {
         "EdDSA".into()
     }

--- a/ucan/src/tests/fixtures/identities.rs
+++ b/ucan/src/tests/fixtures/identities.rs
@@ -1,10 +1,13 @@
+use did_key::{
+    from_existing_key, Ed25519KeyPair, Generate, KeyMaterial as _KeyMaterial, PatchedKeyPair,
+};
+
 use crate::crypto::KeyMaterial;
-use did_key::{Ed25519KeyPair, Generate, KeyPair};
 
 pub struct Identities {
-    pub alice_key: KeyPair,
-    pub bob_key: KeyPair,
-    pub mallory_key: KeyPair,
+    pub alice_key: PatchedKeyPair,
+    pub bob_key: PatchedKeyPair,
+    pub mallory_key: PatchedKeyPair,
 
     pub alice_did: String,
     pub bob_did: String,
@@ -17,18 +20,30 @@ impl Identities {
     pub async fn new() -> Self {
         // NOTE: tweetnacl secret keys concat the public keys, so we only care
         // about the first 32 bytes
-        let alice_key = KeyPair::from(Ed25519KeyPair::from_secret_key(&base64::decode("U+bzp2GaFQHso587iSFWPSeCzbSfn/CbNHEz7ilKRZ1UQMmMS7qq4UhTzKn3X9Nj/4xgrwa+UqhMOeo4Ki8JUw==".as_bytes()).unwrap().as_slice()[0..32]));
-        let bob_key = KeyPair::from(Ed25519KeyPair::from_secret_key(&base64::decode("G4+QCX1b3a45IzQsQd4gFMMe0UB1UOx9bCsh8uOiKLER69eAvVXvc8P2yc4Iig42Bv7JD2zJxhyFALyTKBHipg==".as_bytes()).unwrap().as_slice()[0..32]));
-        let mallory_key = KeyPair::from(Ed25519KeyPair::from_secret_key(&base64::decode("LR9AL2MYkMARuvmV3MJV8sKvbSOdBtpggFCW8K62oZDR6UViSXdSV/dDcD8S9xVjS61vh62JITx7qmLgfQUSZQ==".as_bytes()).unwrap().as_slice()[0..32]));
+        let alice_key = Ed25519KeyPair::from_secret_key(&base64::decode("U+bzp2GaFQHso587iSFWPSeCzbSfn/CbNHEz7ilKRZ1UQMmMS7qq4UhTzKn3X9Nj/4xgrwa+UqhMOeo4Ki8JUw==".as_bytes()).unwrap().as_slice()[0..32]);
+        let alice_keypair = from_existing_key::<Ed25519KeyPair>(
+            &alice_key.public_key_bytes(),
+            Some(&alice_key.private_key_bytes()),
+        );
+        let bob_key = Ed25519KeyPair::from_secret_key(&base64::decode("G4+QCX1b3a45IzQsQd4gFMMe0UB1UOx9bCsh8uOiKLER69eAvVXvc8P2yc4Iig42Bv7JD2zJxhyFALyTKBHipg==".as_bytes()).unwrap().as_slice()[0..32]);
+        let bob_keypair = from_existing_key::<Ed25519KeyPair>(
+            &bob_key.public_key_bytes(),
+            Some(&bob_key.private_key_bytes()),
+        );
+        let mallory_key = Ed25519KeyPair::from_secret_key(&base64::decode("LR9AL2MYkMARuvmV3MJV8sKvbSOdBtpggFCW8K62oZDR6UViSXdSV/dDcD8S9xVjS61vh62JITx7qmLgfQUSZQ==".as_bytes()).unwrap().as_slice()[0..32]);
+        let mallory_keypair = from_existing_key::<Ed25519KeyPair>(
+            &mallory_key.public_key_bytes(),
+            Some(&mallory_key.private_key_bytes()),
+        );
 
         Identities {
-            alice_did: alice_key.get_did().await.unwrap(),
-            bob_did: bob_key.get_did().await.unwrap(),
-            mallory_did: mallory_key.get_did().await.unwrap(),
+            alice_did: alice_keypair.get_did().await.unwrap(),
+            bob_did: bob_keypair.get_did().await.unwrap(),
+            mallory_did: mallory_keypair.get_did().await.unwrap(),
 
-            alice_key,
-            bob_key,
-            mallory_key,
+            alice_key: alice_keypair,
+            bob_key: bob_keypair,
+            mallory_key: mallory_keypair,
         }
     }
 

--- a/ucan/src/tests/helpers.rs
+++ b/ucan/src/tests/helpers.rs
@@ -1,7 +1,7 @@
 use super::fixtures::{EmailSemantics, Identities};
 use crate::{builder::UcanBuilder, capability::CapabilitySemantics};
 use anyhow::Result;
-use did_key::KeyPair;
+use did_key::PatchedKeyPair;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_ipld_dagcbor::{from_slice, to_vec};
 
@@ -12,7 +12,7 @@ where
     Ok(from_slice(&to_vec(data)?)?)
 }
 
-pub async fn scaffold_ucan_builder(identities: &Identities) -> Result<UcanBuilder<KeyPair>> {
+pub async fn scaffold_ucan_builder(identities: &Identities) -> Result<UcanBuilder<PatchedKeyPair>> {
     let email_semantics = EmailSemantics {};
     let send_email_as_bob = email_semantics
         .parse("mailto:bob@email.com".into(), "email/send".into())


### PR DESCRIPTION
Let our deps float on patch versions and fix did-key upstream dep issues. 