### PR TITLE
chore: Update IPLD-adjacent crates

### DIFF
--- a/ucan/Cargo.toml
+++ b/ucan/Cargo.toml
@@ -26,11 +26,11 @@ async-std = "1.0"
 async-trait = "0.1"
 base64 = "0.13"
 bs58 = "0.4"
-cid = "0.8"
+cid = "0.9"
 futures = "0.3"
 instant = { version = "0.1", features = ["wasm-bindgen", "stdweb"] }
-libipld-core = { version = "0.14", features = ["serde-codec", "serde"] }
-libipld-json = "0.14"
+libipld-core = { version = "0.15", features = ["serde-codec", "serde"] }
+libipld-json = "0.15"
 log = "0.4"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This should obviate the Dependabot updates. It's unfortunate that these crates generally have to be updated in lockstep.

BREAKING CHANGE: New version requirements include `cid@0.9`, `libipld-core@0.15` and `libipld-json@0.15`