### PR TITLE
chore: workflow run does not need quotes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
         description: Publish Releases at Anytime
 
   workflow_run:
-    workflows: [ "🧪 Tests and Checks" ]
+    workflows: [ 🧪 Tests and Checks ]
     branches: [main]
     types: [ completed ]
 


### PR DESCRIPTION
super minor. 