### PR TITLE
refactor: switch to tokio mutex instead of async-std

### DIFF
--- a/ucan/Cargo.toml
+++ b/ucan/Cargo.toml
@@ -22,7 +22,6 @@ default = []
 [dependencies]
 anyhow = "1.0"
 async-recursion = "1.0"
-async-std = "1.0"
 async-trait = "0.1"
 base64 = "0.21"
 bs58 = "0.4"


### PR DESCRIPTION
This removes async-std from the deps, which helps with cpu usage in projects that already rely on tokio. Maybe we should use a feature to choose which async lib to use?