### PR TITLE
feat: allow fct and prf to be nullable. Fixes #98

### DIFF
--- a/ucan/src/builder.rs
+++ b/ucan/src/builder.rs
@@ -62,6 +62,18 @@ where
             false => None,
         };
 
+        let facts = if self.facts.is_empty() {
+            None
+        } else {
+            Some(self.facts.clone())
+        };
+
+        let proofs = if self.proofs.is_empty() {
+            None
+        } else {
+            Some(self.proofs.clone())
+        };
+
         Ok(UcanPayload {
             aud: self.audience.clone(),
             iss: self.issuer.get_did().await?,
@@ -69,8 +81,8 @@ where
             nbf: self.not_before,
             nnc: nonce,
             att: self.capabilities.clone(),
-            fct: self.facts.clone(),
-            prf: self.proofs.clone(),
+            fct: facts,
+            prf: proofs,
         })
     }
 

--- a/ucan/src/chain.rs
+++ b/ucan/src/chain.rs
@@ -62,13 +62,15 @@ impl ProofChain {
 
         let mut proofs: Vec<ProofChain> = Vec::new();
 
-        for cid_string in ucan.proofs().iter() {
-            let cid = Cid::try_from(cid_string.as_str())?;
-            let ucan_token = store.require_token(&cid).await?;
-            let proof_chain =
-                Self::try_from_token_string(&ucan_token, now_time, did_parser, store).await?;
-            proof_chain.validate_link_to(&ucan)?;
-            proofs.push(proof_chain);
+        if let Some(ucan_proofs) = ucan.proofs() {
+            for cid_string in ucan_proofs.iter() {
+                let cid = Cid::try_from(cid_string.as_str())?;
+                let ucan_token = store.require_token(&cid).await?;
+                let proof_chain =
+                    Self::try_from_token_string(&ucan_token, now_time, did_parser, store).await?;
+                proof_chain.validate_link_to(&ucan)?;
+                proofs.push(proof_chain);
+            }
         }
 
         let mut redelegations = BTreeSet::<usize>::new();

--- a/ucan/src/tests/builder.rs
+++ b/ucan/src/tests/builder.rs
@@ -61,7 +61,7 @@ async fn it_builds_with_a_simple_example() {
     assert_eq!(ucan.expires_at(), &expiration);
     assert!(ucan.not_before().is_some());
     assert_eq!(ucan.not_before().unwrap(), not_before);
-    assert_eq!(ucan.facts(), &vec![fact_1, fact_2]);
+    assert_eq!(ucan.facts(), &Some(vec![fact_1, fact_2]));
 
     let expected_attenuations =
         Vec::from([CapabilityIpld::from(&cap_1), CapabilityIpld::from(&cap_2)]);
@@ -132,6 +132,6 @@ async fn it_prevents_duplicate_proofs() {
 
     assert_eq!(
         next_ucan.proofs(),
-        &vec![Cid::try_from(ucan).unwrap().to_string()]
+        &Some(vec![Cid::try_from(ucan).unwrap().to_string()])
     )
 }

--- a/ucan/src/tests/ucan.rs
+++ b/ucan/src/tests/ucan.rs
@@ -103,8 +103,6 @@ mod validate {
                     "exp": ucan.expires_at(),
                     "nbf": ucan.not_before(),
                     "att": [],
-                    "fct": [],
-                    "prf": []
                 },
                 "signed_data": ucan.signed_data(),
                 "signature": ucan.signature()

--- a/ucan/src/ucan.rs
+++ b/ucan/src/ucan.rs
@@ -34,8 +34,10 @@ pub struct UcanPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nnc: Option<String>,
     pub att: Vec<CapabilityIpld>,
-    pub fct: Vec<Value>,
-    pub prf: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fct: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prf: Option<Vec<String>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -153,7 +155,7 @@ impl Ucan {
         &self.payload.aud
     }
 
-    pub fn proofs(&self) -> &Vec<String> {
+    pub fn proofs(&self) -> &Option<Vec<String>> {
         &self.payload.prf
     }
 
@@ -173,7 +175,7 @@ impl Ucan {
         &self.payload.att
     }
 
-    pub fn facts(&self) -> &Vec<Value> {
+    pub fn facts(&self) -> &Option<Vec<Value>> {
         &self.payload.fct
     }
 


### PR DESCRIPTION
# Description

Allows `fct` and `prf` to be nullable when consuming, and adhering to canonicalization, will not encode empty values in the resulting JWT.

## Link to issue

#98 

## Type of change

This makes rs-ucan adhere to the spec as of 0.9.0 w/r/t `prf` and `fct` fields which MAY be undefined. This is a breaking change w/r/t some interfaces, but notably also the canonicalization.

## Test plan (required)

Updated existing tests