### PR TITLE
chore: Replace unmaintained/deprecated github actions 

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -29,35 +29,21 @@ jobs:
       - name: Cache Project
         uses: Swatinem/rust-cache@v2
 
-      # Widely adopted suite of Rust-specific boilerplate actions, especially
-      # toolchain/cargo use: https://actions-rs.github.io/
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          override: true
-          components: rustfmt, clippy
           toolchain: ${{ matrix.rust-toolchain }}
+          components: clippy, rustfmt
 
       - name: Check Format
-        uses: actions-rs/cargo@v1
-        with:
-          args: --all -- --check
-          command: fmt
-          toolchain: ${{ matrix.rust-toolchain }}
+        run: cargo +${{ matrix.rust-toolchain }} fmt --all -- --check
 
       - name: Run Linter
-        uses: actions-rs/cargo@v1
-        with:
-          args: --all -- -D warnings
-          command: clippy
-          toolchain: ${{ matrix.rust-toolchain }}
+        run: cargo +${{ matrix.rust-toolchain }} clippy --all -- -D warnings
 
       - name: Install Cargo Audit
         if: ${{ matrix.rust-toolchain == 'stable' }}
-        uses: actions-rs/cargo@v1
-        with:
-          args: --force cargo-audit
-          command: install
+        run: cargo install --force cargo-audit
 
       - name: Run Audit on Deps
         if: ${{ matrix.rust-toolchain == 'stable' }}
@@ -89,9 +75,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          override: true
           toolchain: ${{ matrix.rust-toolchain }}
 
       - name: Run Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
   "ucan-key-support",
 ]
 
+resolver = "2"
+
 # Speedup build on macOS
 # See https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#splitting-debug-information
 [profile.dev]


### PR DESCRIPTION
Originally replaced with rustup one-liners, but [oh boy did it miss caching](https://github.com/ucan-wg/rs-ucan/actions/runs/5181394811) -- the [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) action is actions-rs/toolchain's successor, that does not rely on node (just bash!).

(lint): Additionally set the workspace resolver.