### PR TITLE
chore: add .envrc for activating the flake automatically

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ Cargo.lock
 **/.DS_Store
 README.html
 
+.direnv
+
 dist
 bundle
 lib


### PR DESCRIPTION
This expands upon [Brooke's commit ](https://github.com/QuinnWilton/rs-ucan/commit/71bb83a83fd7c5497ecc68e5f183799e80771caf)to handle automatically hooking the shell to activate the flake, using `direnv`