### PR TITLE
Fix GitHub action headless browser tests

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -82,29 +82,15 @@ jobs:
       - name: Run Tests
         run: cargo test --all
 
-  run-headless-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        crate: [ ucan, ucan-key-support ]
+      - name: Install Rust/WASM Test Dependencies
+        run: |
+          rustup target install wasm32-unknown-unknown
+          cargo install toml-cli
+          WASM_BINDGEN_VERSION=`toml get ./Cargo.lock . | jq '.package | map(select(.name == "wasm-bindgen"))[0].version' | xargs echo`
+          cargo install wasm-bindgen-cli --vers "$WASM_BINDGEN_VERSION"
 
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Cache Project
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          toolchain: stable
+      - name: Setup Chrome and Chromedriver
+        uses: nanasess/setup-chromedriver@v2
 
       - name: Run Rust Headless Browser Tests
-        working-directory: ${{ matrix.crate }}
-        run: wasm-pack test --headless --chrome
+        run: CHROMEDRIVER=/usr/local/bin/chromedriver cargo test --target wasm32-unknown-unknown

--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -82,28 +82,29 @@ jobs:
       - name: Run Tests
         run: cargo test --all
 
-      - name: Install Rust/WASM Test Dependencies
-        run: |
-          rustup target install wasm32-unknown-unknown
-          cargo install toml-cli
-          WASM_BINDGEN_VERSION=`toml get ./Cargo.lock . | jq '.package | map(select(.name == "wasm-bindgen"))[0].version' | xargs echo`
-          cargo install wasm-bindgen-cli --vers "$WASM_BINDGEN_VERSION"
+  run-headless-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [ ucan, ucan-key-support ]
 
-      # See: https://github.com/SeleniumHQ/selenium/blob/5d108f9a679634af0bbc387e7e3811bc1565912b/.github/actions/setup-chrome/action.yml
-      - name: Setup Chrome and Chromedriver
-        run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list.d/google-chrome.list
-          sudo apt-get update -qqy
-          sudo apt-get -qqy install google-chrome-stable
-          CHROME_VERSION=$(google-chrome-stable --version)
-          CHROME_FULL_VERSION=${CHROME_VERSION%%.*}
-          CHROME_MAJOR_VERSION=${CHROME_FULL_VERSION//[!0-9]}
-          sudo rm /etc/apt/sources.list.d/google-chrome.list
-          export CHROMEDRIVER_VERSION=`curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION%%.*}`
-          curl -L -O "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-          unzip chromedriver_linux64.zip && chmod +x chromedriver && sudo mv chromedriver /usr/local/bin
-          chromedriver -version
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Cache Project
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          toolchain: stable
 
       - name: Run Rust Headless Browser Tests
-        run: CHROMEDRIVER=/usr/local/bin/chromedriver cargo test --target wasm32-unknown-unknown
+        working-directory: ${{ matrix.crate }}
+        run: wasm-pack test --headless --chrome


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Switch to `wasm-pack test` for headless browser testing 

The Chrome team recently released Chrome for Testing: https://developer.chrome.com/blog/chrome-for-testing/. As a part of the change, they have ended support for the endpoint we use to determine the required version of Chromedriver.

This PR simplifies our set up by switching to `wasm-pack test`, which automatically installs the correct version of Chromedriver.

## Type of change

- [x] CI fix (non-breaking change that fixes an issue)

## Test plan (required)

The `run-tests` actions should succeed.