### PR TITLE
fix: Ability needs PartialOrd, not Ord

### DIFF
--- a/ucan/src/capability/semantics.rs
+++ b/ucan/src/capability/semantics.rs
@@ -7,7 +7,7 @@ pub trait Scope: ToString + TryFrom<Url> + PartialEq + Clone {
     fn contains(&self, other: &Self) -> bool;
 }
 
-pub trait Ability: Ord + TryFrom<String> + ToString + Clone {}
+pub trait Ability: PartialOrd + TryFrom<String> + ToString + Clone {}
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum ResourceUri<S>


### PR DESCRIPTION
(as far as I understand)
Abilities can be compared, but aren't necessarily related. Nor do they have a 'total order'

# Description
Given my simple example, where abilities have no hierarchy/relation:
```rust
#[derive(PartialEq, Eq, Clone, Debug)]
pub enum StorageAction {
    Read,
    Store,
    Pin,
}
impl Ability for StorageAction {}
```

`Ord` would require me to do this hack, pretending an ability is `Less`, which only works because Abilities are currently only compared via `>=`.
```rust
impl Ord for StorageAction {
    fn cmp(&self, other: &Self) -> Ordering {
        if self == other {
            Ordering::Equal
        } else {
            Ordering::Less
        }
    }
}
```

Correct, I think, would be `PartialOrd`:
```rust
impl PartialOrd for StorageAction {
    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
        if self == other {
            Some(Ordering::Equal)
        } else {
            None
        }
    }
}
```

Of course, introducing hierarchy still works.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan (required)

I `cargo buil[t]` and `cargo test[ed]` :tipping_hand_person: 
